### PR TITLE
Change Argument Types to Objects and Refactor Command Listener/Executor

### DIFF
--- a/src/main/kotlin/me/aberrantfox/kjdautils/api/KUtils.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/api/KUtils.kt
@@ -1,6 +1,7 @@
 package me.aberrantfox.kjdautils.api
 
 import me.aberrantfox.kjdautils.api.dsl.*
+import me.aberrantfox.kjdautils.internal.command.CommandExecutor
 import me.aberrantfox.kjdautils.internal.di.DIService
 import me.aberrantfox.kjdautils.internal.event.EventRegister
 import me.aberrantfox.kjdautils.internal.listeners.CommandListener
@@ -11,6 +12,7 @@ import net.dv8tion.jda.core.JDABuilder
 
 class KUtils(val config: KJDAConfiguration) {
     private var listener: CommandListener? = null
+    private var executor: CommandExecutor? = null
     private var container: CommandsContainer? = null
     private val diService = DIService()
 
@@ -27,7 +29,8 @@ class KUtils(val config: KJDAConfiguration) {
         config.commandPath = commandPath
         config.prefix = prefix
         container = produceContainer(commandPath, diService)
-        listener = CommandListener(config, container!!, jda, logger)
+        executor = CommandExecutor(config, container!!, jda)
+        listener = CommandListener(config, container!!, jda, logger, executor!!)
         registerListener(listener!!)
     }
 

--- a/src/main/kotlin/me/aberrantfox/kjdautils/api/KUtils.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/api/KUtils.kt
@@ -31,12 +31,15 @@ class KUtils(val config: KJDAConfiguration) {
         container = produceContainer(commandPath, diService)
         executor = CommandExecutor(config, container!!, jda)
         listener = CommandListener(config, container!!, jda, logger, executor!!)
-        registerListener(listener!!)
+        registerListeners(listener!!)
     }
 
     fun registerCommandPrecondition(condition: (CommandEvent) -> Boolean) = listener?.addPrecondition(condition)
 
-    fun registerListener(listener: Any) = EventRegister.eventBus.register(listener)
+    fun registerListeners(vararg listeners: Any) =
+            listeners.forEach {
+                EventRegister.eventBus.register(it)
+            }
 }
 
 fun startBot(token: String, operate: KUtils.() -> Unit = {}): KUtils {

--- a/src/main/kotlin/me/aberrantfox/kjdautils/api/dsl/CommandDSL.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/api/dsl/CommandDSL.kt
@@ -1,7 +1,9 @@
 package me.aberrantfox.kjdautils.api.dsl
 
+import com.sun.jdi.connect.Connector
 import me.aberrantfox.kjdautils.extensions.stdlib.sanitiseMentions
 import me.aberrantfox.kjdautils.internal.command.ArgumentType
+import me.aberrantfox.kjdautils.internal.command.Word
 import me.aberrantfox.kjdautils.internal.di.DIService
 import me.aberrantfox.kjdautils.internal.logging.BotLogger
 import me.aberrantfox.kjdautils.internal.logging.DefaultLogger
@@ -69,7 +71,7 @@ open class Command(var log: BotLogger, open val name: String,  var expectedArgs:
     }
 
     fun expect(vararg args: ArgumentType) {
-        val clone = Array(args.size) { arg(ArgumentType.Word) }
+        val clone = Array(args.size) { arg(Word) }
 
         for (x in args.indices) {
             clone[x] = arg(args[x])

--- a/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
@@ -6,8 +6,11 @@ import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.api.dsl.embed
 import me.aberrantfox.kjdautils.api.startBot
-import me.aberrantfox.kjdautils.internal.command.ArgumentType
+import me.aberrantfox.kjdautils.extensions.jda.fullName
+import me.aberrantfox.kjdautils.internal.command.Sentence
+import me.aberrantfox.kjdautils.internal.command.User
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
+import java.text.SimpleDateFormat
 
 data class MyCustomBotConfiguration(val version: String , val token: String)
 
@@ -79,10 +82,24 @@ fun helpCommand(myConfig: MyCustomBotConfiguration, log: MyCustomLogger) = comma
     }
 
     command("echo") {
-        expect(ArgumentType.Sentence)
+        expect(Sentence)
         execute {
             val response = it.args.component1() as String
             it.respond(response)
+        }
+    }
+
+    command("joindate") {
+        expect(User)
+        execute {
+            val target = it.args.component1() as net.dv8tion.jda.core.entities.User
+            val member = it.author.mutualGuilds.first().getMember(target)
+
+            val dateFormat = SimpleDateFormat("yyyy-MM-dd")
+            val joinDateParsed = dateFormat.parse(member.joinDate.toString())
+            val joinDate = dateFormat.format(joinDateParsed)
+
+            it.respond("${member.fullName()}'s join date: $joinDate")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
@@ -25,7 +25,7 @@ fun main(args: Array<String>) {
         val myLog = MyCustomLogger(":: BOT ::")
         registerInjectionObject(myConfig, myLog)
         registerCommands(commandPath, prefix)
-        registerListener(MessageLogger())
+        registerListeners(MessageLogger())
     }
 }
 

--- a/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/examples/MainApp.kt
@@ -6,11 +6,8 @@ import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.api.dsl.embed
 import me.aberrantfox.kjdautils.api.startBot
-import me.aberrantfox.kjdautils.extensions.jda.fullName
 import me.aberrantfox.kjdautils.internal.command.Sentence
-import me.aberrantfox.kjdautils.internal.command.User
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent
-import java.text.SimpleDateFormat
 
 data class MyCustomBotConfiguration(val version: String , val token: String)
 
@@ -86,20 +83,6 @@ fun helpCommand(myConfig: MyCustomBotConfiguration, log: MyCustomLogger) = comma
         execute {
             val response = it.args.component1() as String
             it.respond(response)
-        }
-    }
-
-    command("joindate") {
-        expect(User)
-        execute {
-            val target = it.args.component1() as net.dv8tion.jda.core.entities.User
-            val member = it.author.mutualGuilds.first().getMember(target)
-
-            val dateFormat = SimpleDateFormat("yyyy-MM-dd")
-            val joinDateParsed = dateFormat.parse(member.joinDate.toString())
-            val joinDate = dateFormat.format(joinDateParsed)
-
-            it.respond("${member.fullName()}'s join date: $joinDate")
         }
     }
 }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/extensions/jda/MessageExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/extensions/jda/MessageExtensions.kt
@@ -13,6 +13,8 @@ fun Message.isCommandInvocation(config: KJDAConfiguration) = contentRaw.startsWi
 
 fun Message.deleteIfExists(runnable: () -> Unit = {}) = channel.getMessageById(id).queue { it?.delete()?.queue { runnable() } }
 
+fun Message.isDoubleInvocation(prefix: String) = contentRaw.startsWith(prefix + prefix)
+
 fun Message.mentionsSomeone() = (mentionsEveryone() || mentionedUsers.size > 0 || mentionedRoles.size > 0)
 
 fun Message.isImagePost() =

--- a/src/main/kotlin/me/aberrantfox/kjdautils/extensions/stdlib/StringExtensions.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/extensions/stdlib/StringExtensions.kt
@@ -69,12 +69,13 @@ fun String.toRole(guild: Guild): Role? = guild.getRoleById(this)
 fun String.sanitiseMentions() = this.replace("@", "")
 
 fun String.trimToID(): String =
-        if (this.startsWith("<@") && this.endsWith(">")) {
+        if (this.startsWith("<") && this.endsWith(">")) {
             replace("<", "")
                     .replace(">", "")
                     .replace("@", "")
-                    .replace("!", "") // Mentions with nicknames
+                    .replace("!", "") // User mentions with nicknames
                     .replace("&", "") // Role mentions
+                    .replace("#", "") // Channel mentions
         } else {
             this
         }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/ArgumentConversion.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/ArgumentConversion.kt
@@ -3,60 +3,44 @@ package me.aberrantfox.kjdautils.internal.command
 
 import me.aberrantfox.kjdautils.api.dsl.CommandArgument
 import me.aberrantfox.kjdautils.api.dsl.CommandEvent
-import me.aberrantfox.kjdautils.api.dsl.CommandsContainer
-import me.aberrantfox.kjdautils.extensions.jda.obtainRole
-import me.aberrantfox.kjdautils.extensions.stdlib.*
-import me.aberrantfox.kjdautils.internal.command.ConversionResult.Error
-import me.aberrantfox.kjdautils.internal.command.ConversionResult.Results
-import net.dv8tion.jda.core.JDA
-import net.dv8tion.jda.core.entities.TextChannel
+import me.aberrantfox.kjdautils.internal.command.ArgumentResult.Multiple
+import me.aberrantfox.kjdautils.internal.command.ArgumentResult.Single
+import me.aberrantfox.kjdautils.internal.command.Result.Error
+import me.aberrantfox.kjdautils.internal.command.Result.Results
 
 const val separatorCharacter = "|"
 
-val consumingArgTypes = listOf(ArgumentType.Sentence, ArgumentType.Splitter)
-val multiplePartArgTypes = listOf(ArgumentType.Sentence, ArgumentType.Splitter, ArgumentType.TimeString)
-
-enum class ArgumentType {
-    Integer, Double, Word, Choice, Manual, Sentence, User,
-    Splitter, URL, TimeString, TextChannel, VoiceChannel,
-    Message, Role, Command
-}
-
-sealed class ConversionResult {
-    fun then(function: (List<Any?>) -> ConversionResult): ConversionResult =
+sealed class Result {
+    fun then(function: (List<Any?>) -> Result): Result =
             when (this) {
                 is Results -> function(results)
                 is Error -> this
             }
 
-    fun thenIf(condition: Boolean, function: (List<Any?>) -> ConversionResult) =
+    fun thenIf(condition: Boolean, function: (List<Any?>) -> Result) =
             if (condition) {
                 then(function)
             } else {
                 this
             }
 
-    data class Results(val results: List<Any?>, val consumed: List<String>? = null) : ConversionResult()
-    data class Error(val error: String) : ConversionResult()
+    data class Results(val results: List<Any?>) : Result()
+    data class Error(val error: String) : Result()
 }
 
-fun convertArguments(actual: List<String>, expected: List<CommandArgument>, event: CommandEvent): ConversionResult {
+fun convertArguments(actual: List<String>, expected: List<CommandArgument>, event: CommandEvent): Result {
 
     val expectedTypes = expected.map { it.type }
 
-    if (expectedTypes.contains(ArgumentType.Manual)) {
+    if (expectedTypes.contains(Manual)) {
         return Results(actual)
     }
 
     return convertMainArgs(actual, expected, event)
-            .then {
-                convertOptionalArgs(it, expected, event)
-            }.thenIf(expectedTypes.contains(ArgumentType.Message)) {
-                retrieveMessageArgs(it, expected)
-            } // final and separate message conversion because dependent on text channel arg being converted already
+            .then { convertOptionalArgs(it, expected, event) }
 }
 
-fun convertMainArgs(actual: List<String>, expected: List<CommandArgument>, event: CommandEvent): ConversionResult {
+fun convertMainArgs(actual: List<String>, expected: List<CommandArgument>, event: CommandEvent): Result {
 
     val converted = arrayOfNulls<Any?>(expected.size)
 
@@ -66,24 +50,30 @@ fun convertMainArgs(actual: List<String>, expected: List<CommandArgument>, event
         val actualArg = remaining.first()
 
         val nextMatchingIndex = expected.withIndex().indexOfFirst {
-            matchesArgType(actualArg, it.value.type, event.container) && converted[it.index] == null
+            it.value.type.isValid(actualArg, event) && converted[it.index] == null
         }
         if (nextMatchingIndex == -1) return Error("Couldn't match '$actualArg' with the expected arguments. Try using the `help` command.")
 
         val expectedType = expected[nextMatchingIndex].type
 
-        val result = convertArg(actualArg, expectedType, remaining, event)
+        val result = expectedType.convert(actualArg, remaining.toList(), event)
 
-        when (result) {
-            is Results -> {} // carry on with `Results`
-            is Error -> return result
-        }
+        val convertedValue =
+                when (result) {
+                    is Single -> {
+                        remaining.remove(actualArg)
 
-        val convertedValue = result.results.first()
+                        result.result
+                    }
+                    is Multiple -> {
+                        result.consumed.map {
+                            remaining.remove(it)
+                        }
 
-        result.consumed?.map {
-            remaining.remove(it)
-        }
+                        result.result
+                    }
+                    is ArgumentResult.Error -> return Error(result.error)
+                }
 
         converted[nextMatchingIndex] = convertedValue
     }
@@ -96,7 +86,7 @@ fun convertMainArgs(actual: List<String>, expected: List<CommandArgument>, event
     return Results(converted.toList())
 }
 
-fun convertOptionalArgs(args: List<Any?>, expected: List<CommandArgument>, event: CommandEvent): ConversionResult {
+fun convertOptionalArgs(args: List<Any?>, expected: List<CommandArgument>, event: CommandEvent): Result {
     val zip = args.zip(expected)
 
     val converted =
@@ -113,87 +103,4 @@ fun convertOptionalArgs(args: List<Any?>, expected: List<CommandArgument>, event
             }
 
     return Results(converted)
-}
-
-fun retrieveMessageArgs(args: List<Any?>, expected: List<CommandArgument>): ConversionResult {
-    val channel = args.firstOrNull { it is TextChannel } as TextChannel?
-            ?: throw IllegalArgumentException("Message arguments must be used with a TextChannel argument to be converted automatically")
-
-    val converted = args.zip(expected).map { (arg, expectedArg) ->
-
-        if (expectedArg.type != ArgumentType.Message) return@map arg
-
-        val message =
-                try {
-                    channel.getMessageById(arg as String).complete()
-                } catch (e: RuntimeException) {
-                    null
-                } ?: return Error("Couldn't retrieve message from given channel.")
-
-        return@map message
-    }
-
-    return Results(converted)
-}
-
-private fun matchesArgType(arg: String, type: ArgumentType, container: CommandsContainer): Boolean {
-    return when (type) {
-        ArgumentType.Integer -> arg.isInteger()
-        ArgumentType.Double -> arg.isDouble()
-        ArgumentType.Choice -> arg.isBooleanValue()
-        ArgumentType.URL -> arg.containsURl()
-        ArgumentType.Command -> container.has(arg.toLowerCase())
-        else -> true
-    }
-}
-
-private fun convertArg(arg: String, type: ArgumentType, remaining: MutableList<String>, event: CommandEvent): ConversionResult {
-
-    val jda = event.jda
-    val trimmed = arg.trimToID()
-
-    val tryRetrieve = { action: (JDA) -> Any? -> tryRetrieveSnowflake(jda, action) }
-
-    val result: Any = when (type) {
-        ArgumentType.Integer -> arg.toInt()
-        ArgumentType.Double -> arg.toDouble()
-        ArgumentType.Choice -> arg.toBooleanValue()
-        ArgumentType.Sentence -> joinArgs(remaining)
-        ArgumentType.Splitter -> splitArg(remaining)
-        ArgumentType.TimeString -> convertTimeString(remaining)
-        ArgumentType.Command -> event.container[arg.toLowerCase()]
-        ArgumentType.User -> tryRetrieve { jda.retrieveUserById(trimmed).complete() }
-        ArgumentType.TextChannel -> tryRetrieve { jda.getTextChannelById(trimmed) }
-        ArgumentType.VoiceChannel -> tryRetrieve { jda.getVoiceChannelById(trimmed) }
-        ArgumentType.Role -> tryRetrieve { jda.obtainRole(trimmed) }
-
-        else -> arg
-    } ?: return Error("Couldn't retrieve $type: $arg")
-
-    if (result !is Results) {
-        return if (type in consumingArgTypes) {
-            Results(listOf(result), consumed = remaining.toList())
-        } else {
-            Results(listOf(result), consumed = listOf(arg))
-        }
-    }
-
-    return result
-}
-
-private fun tryRetrieveSnowflake(jda: JDA, action: (JDA) -> Any?): Any? =
-        try {
-            action(jda)
-        } catch (e: RuntimeException) {
-            null
-        }
-
-private fun joinArgs(actual: List<String>) = actual.joinToString(" ")
-
-private fun splitArg(actual: List<String>): List<String> {
-    val joined = joinArgs(actual)
-
-    if (!(joined.contains(separatorCharacter))) return listOf(joined)
-
-    return joined.split(separatorCharacter).toList()
 }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandArguments.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandArguments.kt
@@ -16,48 +16,61 @@ sealed class ArgumentResult {
     data class Error(val error: String) : ArgumentResult()
 }
 
+enum class ConsumptionType {
+    Single, Multiple, All
+}
+
 interface ArgumentType {
+    val consumptionType: ConsumptionType
+
     fun isValid(arg: String, event: CommandEvent): Boolean
     fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult
 }
 
 object IntegerArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = arg.isInteger()
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toInt())
 }
 
-
 object DoubleArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = arg.isDouble()
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toDouble())
 }
 
 object Choice : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = arg.isBooleanValue()
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toBooleanValue())
 }
 
 object URL : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = arg.containsURl()
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg)
 }
 
 object Word : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg)
 }
 
 object TimeString : ArgumentType {
+    override val consumptionType = ConsumptionType.Multiple
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = convertTimeString(args)
 }
 
 object Sentence : ArgumentType {
+    override val consumptionType = ConsumptionType.All
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Multiple(args.joinToString(" "), args)
 }
 
 object UserArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val retrieved = tryRetrieveSnowflake(event.jda) { it.retrieveUserById(arg.trimToID()).complete() }
@@ -71,6 +84,7 @@ object UserArg : ArgumentType {
 }
 
 object Splitter : ArgumentType {
+    override val consumptionType = ConsumptionType.All
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val joined = args.joinToString(" ")
@@ -82,6 +96,7 @@ object Splitter : ArgumentType {
 }
 
 object TextChannelArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val retrieved = tryRetrieveSnowflake(event.jda) { it.getTextChannelById(arg.trimToID()) }
@@ -95,6 +110,7 @@ object TextChannelArg : ArgumentType {
 }
 
 object VoiceChannelArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val retrieved = tryRetrieveSnowflake(event.jda) { it.getVoiceChannelById(arg.trimToID()) }
@@ -108,6 +124,7 @@ object VoiceChannelArg : ArgumentType {
 }
 
 object RoleArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val retrieved = tryRetrieveSnowflake(event.jda) { it.obtainRole(arg.trimToID()) }
@@ -121,6 +138,7 @@ object RoleArg : ArgumentType {
 }
 
 object CommandArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = event.container.has(arg.toLowerCase())
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val command = event.container[arg.toLowerCase()]
@@ -134,6 +152,7 @@ object CommandArg : ArgumentType {
 }
 
 object MessageArg : ArgumentType {
+    override val consumptionType = ConsumptionType.Single
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
         val retrieved = tryRetrieveSnowflake(event.jda) {
@@ -149,6 +168,7 @@ object MessageArg : ArgumentType {
 }
 
 object Manual : ArgumentType {
+    override val consumptionType = ConsumptionType.All
     override fun isValid(arg: String, event: CommandEvent) = true
     override fun convert(arg: String, args: List<String>, event: CommandEvent) = Multiple(args, args)
 }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandArguments.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandArguments.kt
@@ -1,0 +1,161 @@
+package me.aberrantfox.kjdautils.internal.command
+
+import me.aberrantfox.kjdautils.api.dsl.CommandEvent
+import me.aberrantfox.kjdautils.extensions.jda.obtainRole
+import me.aberrantfox.kjdautils.extensions.stdlib.*
+import me.aberrantfox.kjdautils.internal.command.ArgumentResult.*
+import net.dv8tion.jda.core.JDA
+
+sealed class ArgumentResult {
+    /** A result that has only consumed the single argument passed. **/
+    data class Single(val result: Any) : ArgumentResult()
+
+    /** A result that has consumed more than just the argument given. **/
+    data class Multiple(val result: Any, val consumed: List<String>) : ArgumentResult()
+
+    data class Error(val error: String) : ArgumentResult()
+}
+
+interface ArgumentType {
+    fun isValid(arg: String, event: CommandEvent): Boolean
+    fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult
+}
+
+object IntegerArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = arg.isInteger()
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toInt())
+}
+
+
+object DoubleArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = arg.isDouble()
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toDouble())
+}
+
+object Choice : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = arg.isBooleanValue()
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg.toBooleanValue())
+}
+
+object URL : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = arg.containsURl()
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg)
+}
+
+object Word : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Single(arg)
+}
+
+object TimeString : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = convertTimeString(args)
+}
+
+object Sentence : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Multiple(args.joinToString(" "), args)
+}
+
+object UserArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val retrieved = tryRetrieveSnowflake(event.jda) { it.retrieveUserById(arg.trimToID()).complete() }
+
+        return if (retrieved != null) {
+            Single(retrieved)
+        } else {
+            Error("Couldn't retrieve user: $arg")
+        }
+    }
+}
+
+object Splitter : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val joined = args.joinToString(" ")
+
+        if (!joined.contains(separatorCharacter)) return Multiple(listOf(joined), args)
+
+        return Multiple(joined.split(separatorCharacter).toList(), args)
+    }
+}
+
+object TextChannelArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val retrieved = tryRetrieveSnowflake(event.jda) { it.getTextChannelById(arg.trimToID()) }
+
+        return if (retrieved != null) {
+            Single(retrieved)
+        } else {
+            Error("Couldn't retrieve text channel: $arg")
+        }
+    }
+}
+
+object VoiceChannelArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val retrieved = tryRetrieveSnowflake(event.jda) { it.getVoiceChannelById(arg.trimToID()) }
+
+        return if (retrieved != null) {
+            Single(retrieved)
+        } else {
+            Error("Couldn't retrieve user: $arg")
+        }
+    }
+}
+
+object RoleArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val retrieved = tryRetrieveSnowflake(event.jda) { it.obtainRole(arg.trimToID()) }
+
+        return if (retrieved != null) {
+            Single(retrieved)
+        } else {
+            Error("Couldn't retrieve role: $arg")
+        }
+    }
+}
+
+object CommandArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = event.container.has(arg.toLowerCase())
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val command = event.container[arg.toLowerCase()]
+
+        return if (command != null) {
+            Single(command)
+        } else {
+            Error("Couldn't find command: $arg")
+        }
+    }
+}
+
+object MessageArg : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent): ArgumentResult {
+        val retrieved = tryRetrieveSnowflake(event.jda) {
+            event.channel.getMessageById(arg.trimToID()).complete()
+        }
+
+        return if (retrieved != null) {
+            Single(retrieved)
+        } else {
+            Error("Couldn't retrieve a message with the id given from this channel.")
+        }
+    }
+}
+
+object Manual : ArgumentType {
+    override fun isValid(arg: String, event: CommandEvent) = true
+    override fun convert(arg: String, args: List<String>, event: CommandEvent) = Multiple(args, args)
+}
+
+fun tryRetrieveSnowflake(jda: JDA, action: (JDA) -> Any?): Any? =
+        try {
+            action(jda)
+        } catch (e: RuntimeException) {
+            null
+        }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandExecutor.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandExecutor.kt
@@ -6,8 +6,8 @@ import me.aberrantfox.kjdautils.api.dsl.Command
 import me.aberrantfox.kjdautils.api.dsl.CommandEvent
 import me.aberrantfox.kjdautils.api.dsl.CommandsContainer
 import me.aberrantfox.kjdautils.api.dsl.KJDAConfiguration
-import me.aberrantfox.kjdautils.internal.command.ConversionResult.Error
-import me.aberrantfox.kjdautils.internal.command.ConversionResult.Results
+import me.aberrantfox.kjdautils.internal.command.Result.Error
+import me.aberrantfox.kjdautils.internal.command.Result.Results
 import net.dv8tion.jda.core.JDA
 import net.dv8tion.jda.core.entities.Message
 

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandExecutor.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandExecutor.kt
@@ -1,0 +1,49 @@
+package me.aberrantfox.kjdautils.internal.command
+
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.launch
+import me.aberrantfox.kjdautils.api.dsl.Command
+import me.aberrantfox.kjdautils.api.dsl.CommandEvent
+import me.aberrantfox.kjdautils.api.dsl.CommandsContainer
+import me.aberrantfox.kjdautils.api.dsl.KJDAConfiguration
+import me.aberrantfox.kjdautils.internal.command.ConversionResult.Error
+import me.aberrantfox.kjdautils.internal.command.ConversionResult.Results
+import net.dv8tion.jda.core.JDA
+import net.dv8tion.jda.core.entities.Message
+
+internal class CommandExecutor(val config: KJDAConfiguration,
+                               val container: CommandsContainer,
+                               val jda: JDA,
+                               val preconditions: ArrayList<(CommandEvent) -> Boolean> = ArrayList()) {
+
+    fun executeCommand(command: Command, actualArgs: List<String>, message: Message) =
+            launch(CommonPool) {
+                invokeCommand(command, actualArgs, message)
+            }
+
+    private fun invokeCommand(command: Command, actual: List<String>, message: Message) {
+        val channel = message.channel
+        val author = message.author
+
+        getArgCountError(actual, command)?.let {
+            channel.sendMessage(it).queue()
+            return
+        }
+
+        val event = CommandEvent(config, jda, channel, author, message, container, actual)
+        if (!preconditions.all { it.invoke(event) }) return
+
+        val conversionResult = convertArguments(actual, command.expectedArgs.toList(), event)
+
+        when (conversionResult) {
+            is Results -> event.args = conversionResult.results.requireNoNulls()
+            is Error -> {
+                event.safeRespond(conversionResult.error)
+                return
+            }
+        }
+
+        command.execute(event)
+    }
+}
+

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandParsing.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/CommandParsing.kt
@@ -31,7 +31,7 @@ fun getArgCountError(actual: List<String>, cmd: Command): String? {
             return "You didn't enter the minimum number of required arguments: ${cmd.expectedArgs.size - optionalCount}."
         }
     } else {
-        if (actual.size !in argCountRange && !cmd.expectedArgs.contains(arg(ArgumentType.Manual))) {
+        if (actual.size !in argCountRange && !cmd.expectedArgs.contains(arg(Manual))) {
             return "This command requires at least ${argCountRange.start} and a maximum of ${argCountRange.endInclusive} arguments."
         }
     }

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/TimeStringConversion.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/command/TimeStringConversion.kt
@@ -2,12 +2,13 @@ package me.aberrantfox.kjdautils.internal.command
 
 import me.aberrantfox.kjdautils.extensions.stdlib.isDigitOrPeriod
 import me.aberrantfox.kjdautils.extensions.stdlib.isDouble
-import me.aberrantfox.kjdautils.internal.command.ConversionResult.*
+import me.aberrantfox.kjdautils.internal.command.ArgumentResult.*
+import kotlin.Double
 
 private typealias Quantity = Double
 private typealias Quantifier = String
 
-fun convertTimeString(actual: List<String>): ConversionResult {
+fun convertTimeString(actual: List<String>): ArgumentResult {
 
     val possibleEnd = actual.indexOfFirst { toTimeElement(it) == null }
 
@@ -65,7 +66,7 @@ fun convertTimeString(actual: List<String>): ConversionResult {
             .reduce { a, b -> a + b }
 
 
-    return Results(results=listOf(timeInSeconds), consumed=consumed)
+    return Multiple(timeInSeconds, consumed)
 }
 
 private fun toTimeElement(element: String): Any? {

--- a/src/main/kotlin/me/aberrantfox/kjdautils/internal/di/DIService.kt
+++ b/src/main/kotlin/me/aberrantfox/kjdautils/internal/di/DIService.kt
@@ -8,9 +8,17 @@ class DIService {
     fun addElement(element: Any) = elementMap.put(element::class.java, element)
 
     fun invokeReturningMethod(method: Method): Any {
-        val arguments: Array<out Class<*>> = method.parameterTypes ?: return method.invoke(null)
-        val objects = arguments.map { elementMap[it] }.toTypedArray()
+        val arguments: Array<out Class<*>> = method.parameterTypes
 
+        if (arguments.isEmpty())
+            return method.invoke(null)
+
+        val objects = arguments.map { arg ->
+            elementMap.entries
+                    .find { arg.isAssignableFrom(it.key) }
+                    ?.value
+                    ?: throw IllegalStateException("Couldn't inject $arg from registered objects")
+        }.toTypedArray()
 
         return method.invoke(null, *objects)
     }


### PR DESCRIPTION
# Summary 
- Implement argument types as objects
- Refactor/simplify the command listener and executor
- Change `registerListener` to `registerListeners`, and use a `vararg` parameter
- Allow interface implementations/subclasses to be injected where the more general interface/superclass is specified as the argument type